### PR TITLE
webdav interface to dcache 

### DIFF
--- a/bin/dcacheFileInfo
+++ b/bin/dcacheFileInfo
@@ -1,0 +1,140 @@
+#! /bin/bash
+#
+# script to use the webDav dCache API to retrieve checksum and
+# locality (on disk or tape)
+#
+
+usage() {
+echo "
+   dcacheFileInfo [OPTIONS] FILESPEC
+
+     Use the fast webDav interface to dCache to get critical info
+     for a file. This interface requires a voms proxy.  You can
+     get this with \"kinit\" followed by \"vomsCert\"
+
+     FILESPEC should be the full filespec of the dCache file, like
+/pnfs/mu2e/tape/phy-sim/dts/mu2e/CePlusEndpoint/MDC2020t/art/c7/f3/dts.mu2e.CePlusEndpoint.MDC2020t.001202_00000618.art
+      or
+/pnfs/mu2e/tape/phy-sim/mcs/mu2e/DS-cosmic-mix-cat/MDC2018i/art/56/31/mcs.mu2e.DS-cosmic-mix-cat.MDC2018i.001002_00000001.art
+      or, with options -t or -p, a file name, like
+mcs.mu2e.DS-cosmic-mix-cat.MDC2018i.001002_00000001.art
+
+     -c print dcache checksum
+     -l print locality
+        NEARLINE - only on tape, ONLINE- on disk
+        ONLINE_AND_NEARLINE means both
+     -v verbose
+     -t interpret argument as file name only, and lookup the tape location
+     -p interpret argument as file name only, and lookup the persis. location
+     -h print help
+
+"
+}
+
+
+################################
+### main
+################################
+
+FINV=/tmp/x509up_u$UID
+[ -n "$X509_USER_PROXY" ] && FINV="$X509_USER_PROXY"
+
+if [ ! -e $FINV ]; then
+    echo "ERROR - could not find x509 proxy"
+    exit 1
+fi
+
+DOCRC=""
+DOLOC=""
+VERBOSE=""
+LTAPE=""
+LDISK=""
+
+while getopts cltpvh OPT; do
+    case $OPT in
+        c)
+            DOCRC=yes
+            ;;
+        l)
+            DOLOC=yes
+            ;;
+        t)
+            LTAPE=yes
+            ;;
+        p)
+            LDISK=yes
+            ;;
+        v)
+            VERBOSE=yes
+            ;;
+        h)
+            usage
+            exit 0
+            ;;
+        *)
+            echo unknown option, exiting
+            usage
+            exit 1
+            ;;
+     esac
+done
+
+# shift away the switches to get remainder
+shift $(expr $OPTIND - 1 )
+FFS="$@"
+
+if [ -z "$FFS"  ]; then
+    echo "ERROR - one pnfs filespec argument is required"
+    exit 1
+fi
+
+if [[ -n "$LTAPE" || -n "$LDISK" ]]; then
+    if ! command -v mu2eabsname_tape > /dev/null 2>&1 ; then
+        source /cvmfs/mu2e.opensciencegrid.org/setupmu2e-art.sh
+        setup mu2efilename
+    fi
+    if [ $LTAPE ]; then
+        FFS=$(echo -n $FFS | mu2eabsname_tape )
+    else
+        FFS=$(echo -n $FFS | mu2eabsname_disk )
+    fi
+fi
+#if [ "$STUB" != "/pnfs"  ]; then
+#    echo "ERROR - one pnfs filespec argument is required"
+#    exit 1
+#fi
+
+# canonical dCache filespec
+CFFS=$(echo $FFS | sed 's|/pnfs|/pnfs/fnal.gov/usr|' )
+
+
+
+#curl -L --capath /etc/grid-security/certificates --cert $FINV --cacert $FINV --key $FINV -X GET "https://fndca1.fnal.gov:3880/api/v1/namespace${CFFS}?checksum=true&locality=true"
+
+VS=" -s "
+[ $VERBOSE ] && VS=""
+
+ANS=$( curl $VS -L --capath /etc/grid-security/certificates --cert $FINV --cacert $FINV --key $FINV -X GET "https://fndca1.fnal.gov:3880/api/v1/namespace${CFFS}?checksum=true&locality=true" )
+
+
+RC=$?
+if [ $RC -ne 0 ]; then
+    echo "ERROR - curl command failed"
+    exit 1
+fi
+
+[ $VERBOSE ] && echo -n "$ANS"
+
+CRC=""
+if [ $DOCRC ]; then
+    CRC=$( echo -n "$ANS" | grep value | tr -d '":,' | awk '{print $2}' )
+fi
+
+LOC=""
+if [ $DOLOC ]; then
+  LOC=$( echo -n "$ANS" | grep fileLocality | tr -d '":,' | awk '{print$2}' )
+fi
+
+[ ${CRC}${LOC} ] && echo $CRC $LOC
+
+exit 0

--- a/bin/samListLocations
+++ b/bin/samListLocations
@@ -1,10 +1,93 @@
 #!/bin/bash
+#
+# script to list the SAM file locations of a set of files
+# in a dataset, or similar file selection
+#
+
+usage() {
+
+    echo "
+
+     samListLocations [OPTIONS]  <SAMWEB-ARGS>
+
+     Script to take a dataset definition (or other format input
+     to samweb list-file-locations) and retrieve the locations
+     and rewrite the format to a dCache filespec.
+
+     <SAMWEB-ARGS>
+     The arguments to the samweb list-file-locations command
+
+     [OPTIONS]
+     -d only files on disk will be printed
+     -f files on disk will be printed first, followed by the rest
+     -h print this help
+
+     Using the disk options requires a valid x509 cert
+     and will cause the script to run slower ( ~200 files per min )
+
+     examples:
+
+     samListLocations --defname dts.mu2e.CePlusEndpoint.MDC2020t.art
+     samListLocations -d --dim \"dh.dataset=mcs.mu2e.DS-cosmic-mix-cat.MDC2018i.001002_00000001.art\"
+
+"
+}
+
+
+DODISK=""
+DOFIRST=""
+DOLOC=""
+
+if [[ "$1" == "-h" || "$1" == "--help" ]]; then
+    usage
+    exit 0
+fi
+
+TMPF=""
+if [ "$1" == "-d" ]; then
+    shift
+    DODISK=yes
+    DOLOC=tes
+elif [ "$1" == "-f" ]; then
+    shift
+    DOFIRST=yes
+    DOLOC=yes
+    TMPF=$(mktemp)
+fi
+
+
+
 OLDIFS=${IFS}
 samweb list-file-locations "${@}" | while read line
 do
    IFS=$'\t'
    read -a strarr <<< "$line"
    FILEPATH=`echo ${strarr[0]} | cut -d':' -f2`
-   echo "${FILEPATH}/${strarr[1]}"
+   FILESPEC=${FILEPATH}/${strarr[1]}
+
+   LOC=""
+   if [ $DOLOC ]; then
+       LOC=$( dcacheFileInfo -l $FILESPEC )
+   fi
+
+   if [ $DODISK ]; then
+       [ "$LOC" == "ONLINE_AND_NEARLINE" ] && echo "$FILESPEC"
+   elif [ $DOFIRST ]; then
+       if [ "$LOC" == "ONLINE_AND_NEARLINE" ]; then
+           echo "$FILESPEC"
+       else
+           echo "$FILESPEC" >> $TMPF
+       fi
+   else
+       echo "$FILESPEC"
+   fi
+
 done
 IFS=${OLDIFS}
+
+if [ $DOFIRST ]; then
+    cat $TMPF
+    rm -f $TMPF
+fi
+
+exit 0


### PR DESCRIPTION
dcacheFileInfo uses the webDav interface to the dcache database to get file checksum or locality. I'm trying to confirm that we can use this interface heavily, but I think so.  This should be a good replacement for "dot commands" and can be run from the grid.
At Dave's request, I've added switches to samListLocations to only list, or list first, the files on disk.